### PR TITLE
feat: horizontally align lightbox images

### DIFF
--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -30,6 +30,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     flex: 1,
     justifyContent: "center",
+    alignItems: "center",
     // Android pan handlers crash without this declaration:
     backgroundColor: "transparent",
   },


### PR DESCRIPTION
Very long vertical images used to be on the very left of the screen. With this change they are now centered.